### PR TITLE
Added support for block sound effects

### DIFF
--- a/src/Components/TileTypeEditor.js
+++ b/src/Components/TileTypeEditor.js
@@ -31,6 +31,12 @@ const fields = [
     info: 'The image. uhduhhhh',
   },
   {
+    prop: 'sound',
+    label: 'Sound URL',
+    type: 'text',
+    info: 'URL for the sound that should be played.',
+  },
+  {
     prop: 'color',
     label: 'Color',
     type: 'text',

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -29,10 +29,13 @@ export class Game {
     this.worldElement = new WorldElement(rootElement);
     this.hud = new Hud(rootElement);
     this.dialog = new Dialog(rootElement);
-    this.sounds = {
-      j: new Audio('https://static.heironimus.info/sound/PinkFast.ogg'),
-      p: new Audio('https://static.heironimus.info/sound/SloppyPoopSoft.ogg'),
-    };
+
+    // Setup sounds for blocks that support sound.
+    this.sounds = {};
+    Object.values(typeIndex)
+      .filter((type) => type.sound)
+      .forEach((type) => (this.sounds[type.id] = new Audio(type.sound)));
+
     new VersionElement(rootElement);
 
     this.world = {};
@@ -339,7 +342,7 @@ export class Game {
   }
   collect(typeId) {
     this.setCollectible(typeId, this.numCollected(typeId) + 1);
-    this.sounds[typeId].play();
+    this.sounds[typeId]?.play();
   }
   setPoop(poop) {
     this.poop = Math.max(0, Math.min(this.maxPoop, poop));
@@ -354,7 +357,7 @@ export class Game {
     if ((x !== you.x || y !== you.y) && !world[`${x}_${y}`]) {
       this.addTile({x, y, type: typeIndex.p});
       this.setPoop(this.poop - 1);
-      this.sounds.p.play();
+      this.sounds.p?.play();
     }
   }
   updateViewport() {

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -29,9 +29,9 @@ export class Game {
     this.worldElement = new WorldElement(rootElement);
     this.hud = new Hud(rootElement);
     this.dialog = new Dialog(rootElement);
-    this.collectableSound = new Audio(
-      'https://static.heironimus.info/sound/PinkFast.ogg'
-    );
+    this.sounds = {
+      j: new Audio('https://static.heironimus.info/sound/PinkFast.ogg'),
+    };
     new VersionElement(rootElement);
 
     this.world = {};
@@ -338,7 +338,7 @@ export class Game {
   }
   collect(typeId) {
     this.setCollectible(typeId, this.numCollected(typeId) + 1);
-    this.collectableSound.play();
+    this.sounds[typeId].play();
   }
   setPoop(poop) {
     this.poop = Math.max(0, Math.min(this.maxPoop, poop));

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -187,6 +187,7 @@ export class Game {
         this.damage(b, this.eatSpeed);
         this.setHealth(this.health + b.type.healing * this.eatSpeed);
         this.setPoop(this.poop + b.type.makePoop * this.eatSpeed);
+        this.sounds[b.type.id]?.play();
       }
       if (b?.type.diggable) this.damage(b, this.digSpeed);
     }

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -31,6 +31,7 @@ export class Game {
     this.dialog = new Dialog(rootElement);
     this.sounds = {
       j: new Audio('https://static.heironimus.info/sound/PinkFast.ogg'),
+      p: new Audio('https://static.heironimus.info/sound/SloppyPoopSoft.ogg'),
     };
     new VersionElement(rootElement);
 
@@ -353,6 +354,7 @@ export class Game {
     if ((x !== you.x || y !== you.y) && !world[`${x}_${y}`]) {
       this.addTile({x, y, type: typeIndex.p});
       this.setPoop(this.poop - 1);
+      this.sounds.p.play();
     }
   }
   updateViewport() {

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -29,6 +29,9 @@ export class Game {
     this.worldElement = new WorldElement(rootElement);
     this.hud = new Hud(rootElement);
     this.dialog = new Dialog(rootElement);
+    this.collectableSound = new Audio(
+      'https://static.heironimus.info/sound/PinkFast.ogg'
+    );
     new VersionElement(rootElement);
 
     this.world = {};
@@ -335,6 +338,7 @@ export class Game {
   }
   collect(typeId) {
     this.setCollectible(typeId, this.numCollected(typeId) + 1);
+    this.collectableSound.play();
   }
   setPoop(poop) {
     this.poop = Math.max(0, Math.min(this.maxPoop, poop));


### PR DESCRIPTION
This change adds a new property to a block, called `sound`. It contains the URL to a sound file that should be played for this block type. This property currently appears on all block types, but is only supported on the following block types:

- **grass**: when the wombat eats it
- **poop**: when the wombat poops
- **jewel**: when the wombat collects a jewel

I hope to add support for the other block types in the future.