### PR TITLE
Sound Logic Cleanup

### DIFF
--- a/src/Components/GameConfig.js
+++ b/src/Components/GameConfig.js
@@ -107,12 +107,6 @@ const fields = [
     info: 'How quickly does water slow you down?',
   },
   {
-    prop: 'gameStartSound',
-    label: 'Game Start Sound',
-    type: 'text',
-    info: 'This is the URL for the sound that is played when the game is started.',
-  },
-  {
     prop: 'gameOverSound',
     label: 'Game Over Sound',
     type: 'text',

--- a/src/Components/GameConfig.js
+++ b/src/Components/GameConfig.js
@@ -107,6 +107,12 @@ const fields = [
     info: 'How quickly does water slow you down?',
   },
   {
+    prop: 'gameStartSound',
+    label: 'Game Start Sound',
+    type: 'text',
+    info: 'This is the URL for the sound that is played when the game is started.',
+  },
+  {
     prop: 'gameOverSound',
     label: 'Game Over Sound',
     type: 'text',

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -73,19 +73,25 @@ export class Game {
     this.setPoop(this.poop);
     this.you.el.update(this.you);
     this.worldElement.update(this.you);
-    this.playSound('gameStart');
   }
   buildSounds(config, typeIndex) {
     const sounds = {};
+
     Object.values(typeIndex)
       .filter((type) => type.sound)
       .forEach((type) => (sounds[type.id] = new Audio(type.sound)));
+
+    const soundSettingSuffix = 'Sound';
     Object.keys(config)
-      .filter((key) => key.endsWith('Sound') && config[key])
+      .filter((key) => key.endsWith(soundSettingSuffix) && config[key])
       .forEach((key) => {
-        const soundName = key.substring(0, key.length - 'Sound'.length);
+        const soundName = key.substring(
+          0,
+          key.length - soundSettingSuffix.length
+        );
         sounds[soundName] = new Audio(config[key]);
       });
+
     return sounds;
   }
   playSound(sound) {

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -39,6 +39,8 @@ export class Game {
       this.sounds.fallDamage = new Audio(config.fallDamageSound);
     if (config.gameOverSound)
       this.sounds.gameOver = new Audio(config.gameOverSound);
+    if (config.gameStartSound)
+      this.sounds.gameStart = new Audio(config.gameStartSound);
 
     new VersionElement(rootElement);
 
@@ -82,6 +84,7 @@ export class Game {
     this.setPoop(this.poop);
     this.you.el.update(this.you);
     this.worldElement.update(this.you);
+    this.sounds.gameStart?.play();
   }
   iterate(pressing) {
     this.moveWombat(pressing);


### PR DESCRIPTION
Created a `buildSounds` and a `playSound` method to cleanup the sound logic. 

The `buildSounds` method will load any TypeType's `sound` property and any `GameConfig` property that ends with `Sound` and return the sounds as an object.

The `playSound` method will play the indicated sound, if it exists. It does nothing if the sound does not exist. The argument to the `playSound` method is either the name of the sound to play (e.g., `gameOver`, `fallDamage`, etc.) or the block/tile's id (e.g., `b`, `p`, `g`, `k`, etc.).