### PR TITLE
Various Updates for Tile "On" Events

### DIFF
--- a/src/Components/WorldEditor.js
+++ b/src/Components/WorldEditor.js
@@ -15,10 +15,10 @@ const getCoords = (e, scale, xCoord, yCoord) => ({
   y: Math.floor((e.clientY - innerHeight / 2) / scale) + yCoord,
 });
 
-const getTitle = (user, tstamp, userIndex) => {
+const getTitle = (user, tstamp, userIndex, x, y) => {
   if (!user || !tstamp) return '';
   const name = userIndex[user]?.name || user;
-  return `Placed by ${name} ${timeAgo(Date.now() - tstamp)}`;
+  return `Placed at (${x}, ${y}) by ${name} ${timeAgo(Date.now() - tstamp)}`;
 };
 
 const Tiles = ({world, tileTypeIndex, userIndex, setTileLogicCoords}) =>
@@ -26,7 +26,7 @@ const Tiles = ({world, tileTypeIndex, userIndex, setTileLogicCoords}) =>
     <div
       key={key}
       className="tile"
-      title={getTitle(user, tstamp, userIndex)}
+      title={getTitle(user, tstamp, userIndex, x, y)}
       style={{
         transform: `translate(${x * CSS_SIZE}px, ${y * CSS_SIZE}px)`,
         background: getBackground(tileTypeIndex[tileType]),

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -189,6 +189,9 @@ export class Game {
   }
   deleteTile(tile) {
     tile.el.destroy();
+    if (tile.name !== undefined && this.namedTiles[tile.name] !== undefined) {
+      delete this.namedTiles[tile.name];
+    }
     delete this.world[`${tile.x}_${tile.y}`];
   }
   changeTileType(tile, type) {

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -50,7 +50,6 @@ export class Game {
     this.setGameBackground(gameConfig.backgroundUrl);
 
     const typeIndex = {};
-    this.namedTiles = {};
     let youPos;
     for (const type of Object.values(tileTypes)) {
       typeIndex[type.id] = type;
@@ -67,10 +66,8 @@ export class Game {
           type: typeIndex[tileType],
           onSpace: compile(onSpace),
           onTouch: compile(onTouch),
+          name,
         };
-        if (name) {
-          this.namedTiles[name] = world[key];
-        }
       } else {
         delete world[key];
       }
@@ -86,6 +83,15 @@ export class Game {
     this.worldElement.clear();
     this.world = {};
     for (const key in world) this.addTile(world[key]);
+
+    // Build "Named Tiles" object for quick retrieval
+    this.namedTiles = Object.values(this.world)
+      .filter((tile) => tile.name !== undefined)
+      .reduce(
+        (output, tile) =>
+          Object.assign(output, {[tile.name]: this.getTile(tile.x, tile.y)}),
+        {}
+      );
 
     this.typeIndex = typeIndex;
     this.you = {

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -82,16 +82,8 @@ export class Game {
 
     this.worldElement.clear();
     this.world = {};
+    this.namedTiles = {};
     for (const key in world) this.addTile(world[key]);
-
-    // Build "Named Tiles" object for quick retrieval
-    this.namedTiles = Object.values(this.world)
-      .filter((tile) => tile.name !== undefined)
-      .reduce(
-        (output, tile) =>
-          Object.assign(output, {[tile.name]: this.getTile(tile.x, tile.y)}),
-        {},
-      );
 
     this.typeIndex = typeIndex;
     this.you = {
@@ -186,6 +178,9 @@ export class Game {
       ...tile,
       el: new TileElement(tile, this.worldElement),
     };
+    if (tile.name !== undefined) {
+      this.namedTiles[tile.name] = this.world[`${tile.x}_${tile.y}`];
+    }
   }
   deleteTile(tile) {
     tile.el.destroy();

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -90,7 +90,7 @@ export class Game {
       .reduce(
         (output, tile) =>
           Object.assign(output, {[tile.name]: this.getTile(tile.x, tile.y)}),
-        {}
+        {},
       );
 
     this.typeIndex = typeIndex;

--- a/src/game/compile.js
+++ b/src/game/compile.js
@@ -35,6 +35,7 @@ const changeTileType = game.changeTileType.bind(game);
 const you = game.you;
 const poop = game.poop;
 const health = game.health;
+const namedTiles = game.namedTiles;
 
 ${str}`;
 

--- a/src/game/compile.js
+++ b/src/game/compile.js
@@ -25,6 +25,7 @@ const setHealth = game.setHealth.bind(game);
 
 const moveTile = game.moveTile.bind(game);
 const addTile = game.addTile.bind(game);
+const deleteTile = game.deleteTile.bind(game);
 const isEmpty = game.isEmpty.bind(game);
 const getTile = game.getTile.bind(game);
 const getTileByName = game.getTileByName.bind(game);


### PR DESCRIPTION
- Updated the popup message (i.e., title attribute) of a tile to display the (x, y) location. This can be helpful when writing "On Touch" and "On Space" event handlers.
- The deleteTile method can now be easily called from "On Touch" and "On Space" events.
- This addresses the bug where tiles in the `namedTiles` property did not have their "el" properties.
- Event handlers can now reference named tiles using the "namedTiles" object. For example, a tile with the name "myNamedTile", can be referenced using `namedTiles.myNamedTile`.
