### PR TITLE
Fixed issue updating image URLs in editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mortal-wombat",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mortal-wombat",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "dependencies": {
         "@monaco-editor/react": "^4.5.1",
         "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mortal-wombat",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "private": true,
   "homepage": "https://mortalwombat.app",
   "scripts": {

--- a/src/Components/TileTypeEditor.js
+++ b/src/Components/TileTypeEditor.js
@@ -35,7 +35,7 @@ const fields = [
     info: `A url to an image.`,
   },
   ...['walking', 'pushing', 'jumping', 'digging', 'crouching'].map((n) => ({
-    prop: `${n}Image$`,
+    prop: `${n}Image`,
     label: `${capitalize(n)} Image URL`,
     type: 'text',
     info: `A url to an image for ${n}.`,

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -61,18 +61,13 @@ export const defaultTileTypes = {
     color: 'red',
     density: '1.1',
     id: 'w',
-    image:
-      'https://piskel-imgstore-b.appspot.com/img/610cc71e-cdb9-11ec-8e05-2f9ec14027c3.gif',
-    walkingImage:
-      'https://piskel-imgstore-b.appspot.com/img/253fba5c-cdb9-11ec-acf8-2f9ec14027c3.gif',
-    pushingImage:
-      'https://piskel-imgstore-b.appspot.com/img/586bb7e6-cdb9-11ec-a846-2f9ec14027c3.gif',
-    jumpingImage:
-      'https://piskel-imgstore-b.appspot.com/img/4439c4fd-cdb9-11ec-9ce8-2f9ec14027c3.gif',
-    diggingImage:
-      'https://piskel-imgstore-b.appspot.com/img/3a751840-cdb9-11ec-8175-2f9ec14027c3.gif',
+    image: 'https://static.heironimus.info/image/WombatStanding.gif',
+    walkingImage: 'https://static.heironimus.info/image/WombatStanding.gif',
+    pushingImage: 'https://static.heironimus.info/image/WombatPushing.gif',
+    jumpingImage: 'https://static.heironimus.info/image/WombatJumping.gif',
+    diggingImage: 'https://static.heironimus.info/image/WombatDigger.gif',
     crouchingImage:
-      'https://piskel-imgstore-b.appspot.com/img/32ac8f9e-cdb9-11ec-9e05-2f9ec14027c3.gif',
+      'https://static.heironimus.info/image/WombatBendingDown.gif',
     label: 'wombat',
     order: '4',
   },


### PR DESCRIPTION
This pull request updates the default wombat tile images to use new URLs and fixes a property naming issue in the tile type editor. It also bumps the package version to reflect these changes.

**Details**

* Updated the default wombat tile images in `defaultTileTypes` to use new URLs hosted at `static.heironimus.info` instead of the previous `piskel-imgstore-b.appspot.com` links. This affects the `image`, `walkingImage`, `pushingImage`, `jumpingImage`, `diggingImage`, and `crouchingImage` properties.
* Fixed a property naming bug in `TileTypeEditor.js` by removing the stray `$` from properties like `walkingImage`, ensuring they are named correctly (e.g., `walkingImage`, not `walkingImage$`).
* Bumped the app version in `package.json` from `0.1.42` to `0.1.43` to reflect these updates.

**Remaining Issues**

* Some of the other default tile type images that were hosted on `piskel-imgstore-b.appspot.com` are still broken. I will try to recover or rebuild the missing images eventually.